### PR TITLE
[u-mr1] BoardConfig: Move androidboot.hardware to boot command line

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -26,7 +26,7 @@ $(warning Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)", using defa
 endif
 
 # Kernel cmdline
-BOARD_KERNEL_CMDLINE += androidboot.hardware=pdx246
+BOARD_BOOTCONFIG += androidboot.hardware=pdx246
 BOARD_KERNEL_CMDLINE += androidboot.fstab_suffix=pdx246
 
 # FB console


### PR DESCRIPTION
Device uses bootconfig feature and any androidboot.* kernel
cmdline options should be moved to BOARD_BOOTCONFIG.
androidboot.fstab_suffix is not moved because it's defined
by bootloader and we can not overwrite it.