### PR TITLE
[v-mr1] aosp_xqes54: Remove Dalvik heap configuration

### DIFF
--- a/aosp_xqes54.mk
+++ b/aosp_xqes54.mk
@@ -22,7 +22,6 @@ TARGET_KERNEL_CONFIG := aosp_columbia_pdx246_defconfig
 
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/pdx246/device.mk)
-$(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base_telephony.mk)
 
 PRODUCT_NAME := aosp_xqes54


### PR DESCRIPTION
Since Dalvik was discontinued many years ago, remove the
inheritance of this configuration. In any case, it was not
suitable for the device configuration, as it has more than
6 GB of RAM.

For compatibility reasons, since some system components may
still rely on these properties, the last available config
provided by AOSP, which is for 6 GB devices, will be
inherited in the common repo. Because all our devices have
at least 6 GB of RAM or more.